### PR TITLE
Remove old ffmpeg link

### DIFF
--- a/README.md
+++ b/README.md
@@ -172,7 +172,7 @@ __________________________________________________________
 	
 (NOTE: The pre-built binaries are made wth buildAL(x64/x86))
 	
-6. Download the latest ffmpeg shared from https://ffmpeg.zeranoe.com/builds/ depending on the architecture you want to use
+6. Download the latest ffmpeg shared from https://www.gyan.dev/ffmpeg/builds/ depending on the architecture you want to use
 
 7. Extract the FFmpeg DLLs to your current game directory 
 


### PR DESCRIPTION
Because old ffmpeg site is offline, I will add 32 compilation guide as well

old ffmpeg link was shutdown.
if not suitible as it only provides 64 bit, i will provide instructions to compile a shared build for 32 using msys2 to be used with vs 2019